### PR TITLE
Retrieve eval prediction

### DIFF
--- a/tf2/run.py
+++ b/tf2/run.py
@@ -395,10 +395,10 @@ def perform_evaluation(model, builder, eval_steps, ckpt, strategy, topology):
       return outputs, labels
 
     iterator = iter(ds)
+    all_outputs = []
     for i in range(eval_steps):
       outputs, labels = run_single_step(iterator)
-      # logging.info(outputs)
-      # logging.info(labels)
+      all_outputs.append((outputs, labels))
       logging.info('Completed eval for %d / %d steps', i + 1, eval_steps)
     logging.info('Finished eval for %s', ckpt)
 

--- a/tf2/run.py
+++ b/tf2/run.py
@@ -397,8 +397,8 @@ def perform_evaluation(model, builder, eval_steps, ckpt, strategy, topology):
     iterator = iter(ds)
     for i in range(eval_steps):
       outputs, labels = run_single_step(iterator)
-      logging.info(outputs)
-      logging.info(labels)
+      # logging.info(outputs)
+      # logging.info(labels)
       logging.info('Completed eval for %d / %d steps', i + 1, eval_steps)
     logging.info('Finished eval for %s', ckpt)
 

--- a/tf2/run.py
+++ b/tf2/run.py
@@ -398,7 +398,7 @@ def perform_evaluation(model, builder, eval_steps, ckpt, strategy, topology):
     all_outputs = []
     for i in range(eval_steps):
       outputs, labels = run_single_step(iterator)
-      all_outputs.append((outputs, labels))
+      all_outputs.append((outputs.numpy(), labels.numpy()))
       logging.info('Completed eval for %d / %d steps', i + 1, eval_steps)
     logging.info('Finished eval for %s', ckpt)
 


### PR DESCRIPTION
**Motivation**: Collect the raw NN predictions (e.g. for use in batch inference)

**Calling args**:
```
DATA_DIR="gs://selfsupervised-remote-sensing-data/imagenet"
MODEL_DIR="gs://selfsupervised-remote-sensing-tmp/model_0910_tpu"
CHKPT_DIR="gs://simclr-checkpoints-tf2/simclrv2/pretrained/r50_1x_sk0/saved_model"
TPU_NAME="john-tpu-v3-8-instance"

time python /simclr/tf2/run.py \
--mode=eval \
--global_bn=True \
--optimizer=lars \
--learning_rate=0.005 \
--learning_rate_scaling=sqrt \
--weight_decay=0 \
--warmup_epochs=0 \
--dataset=imagenet2012:5.0.0 \
--image_size=224 \
--eval_split=validation \
--data_dir=$DATA_DIR \
--model_dir=$MODEL_DIR \
--checkpoint=$CHKPT_DIR \
--num_proj_layers=3 \
--ft_proj_selector=1 \
--eval_batch_size=1024 \
--use_tpu=True \
--tpu_name=$TPU_NAME
```

**Behavior before change**:
Evaluates imagenet epoch in <1 s

```
I0929 12:07:12.810371 140615176439616 run.py:398] Completed eval for 1 / 49 steps
I0929 12:07:12.813882 140615176439616 run.py:398] Completed eval for 2 / 49 steps
I0929 12:07:12.816925 140615176439616 run.py:398] Completed eval for 3 / 49 steps
...
I0929 12:07:12.939356 140615176439616 run.py:398] Completed eval for 49 / 49 steps
I0929 12:07:12.939444 140615176439616 run.py:399] Finished eval for gs://selfsupervised-remote-sensing-tmp/model_0910_tpu/ckpt-2502
I0929 12:08:00.390941 140615176439616 run.py:403] Writing summaries for 2502 step
I0929 12:08:00.395740 140615176439616 metrics.py:73] Step: [2502] eval/regularization_loss = 0.000000
I0929 12:08:00.403419 140615176439616 metrics.py:73] Step: [2502] eval/label_top_1_accuracy = 0.017680
I0929 12:08:00.409486 140615176439616 metrics.py:73] Step: [2502] eval/label_top_5_accuracy = 0.063320
I0929 12:08:00.558661 140615176439616 run.py:412] {'eval/regularization_loss': 0.0, 'eval/label_top_1_accuracy': 0.01768, 'eval/label_top_5_accuracy': 0.06332, 'global_step': 2502}
2021-09-29 12:08:08.573502: W tensorflow/python/util/util.cc:348] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.
WARNING:tensorflow:Skipping full serialization of Keras layer <model.Model object at 0x7fe2fc754f60>, because it is not built.
W0929 12:08:08.958053 140615176439616 save_impl.py:72] Skipping full serialization of Keras layer <model.Model object at 0x7fe2fc754f60>, because it is not built.
W0929 12:08:27.846506 140615176439616 save.py:254] Found untraced functions such as resnet_layer_call_and_return_conditional_losses, resnet_layer_call_fn, projection_head_layer_call_and_return_conditional_losses, projection_head_layer_call_fn, head_supervised_layer_call_and_return_conditional_losses while saving (showing 5 of 1330). These functions will not be directly callable after loading.
INFO:tensorflow:Assets written to: gs://selfsupervised-remote-sensing-tmp/model_0910_tpu/saved_model/2502/assets
I0929 12:08:34.298884 140615176439616 builder_impl.py:781] Assets written to: gs://selfsupervised-remote-sensing-tmp/model_0910_tpu/saved_model/2502/assets
INFO:tensorflow:Waiting for new checkpoint at gs://selfsupervised-remote-sensing-tmp/model_0910_tpu
```

**behavior after change**
```
I0929 13:51:09.740442 139630670669632 tpu.py:1381] TPU has inputs with dynamic shapes: [<tf.Tensor 'Const:0' shape=() dtype=int32>, <tf.Tensor 'cond_8/Identity:0' shape=(None, 224, 224, 3) dtype=float32>, <tf.Tensor 'cond_8/Identity_1:0' shape=(None, 1000) dtype=float32>]
Traceback (most recent call last):
  File "/simclr/tf2/run.py", line 675, in <module>
    app.run(main)
  File "/usr/local/lib/python3.6/dist-packages/absl/app.py", line 303, in run
    _run_main(main, args)
  File "/usr/local/lib/python3.6/dist-packages/absl/app.py", line 251, in _run_main
    sys.exit(main(argv))
  File "/simclr/tf2/run.py", line 521, in main
    topology)
  File "/simclr/tf2/run.py", line 401, in perform_evaluation
    all_outputs.append((outputs.numpy(), labels.numpy()))
AttributeError: 'PerReplica' object has no attribute 'numpy'
```