### PR TITLE
pass string sample id

### DIFF
--- a/tf2/data.py
+++ b/tf2/data.py
@@ -64,7 +64,8 @@ def build_input_fn(builder, global_batch_size, topology, is_training):
       label = tf.one_hot(label, num_classes)
       sample_id_len = random.randint(10, 100)
       letters = random.choices(string.ascii_lowercase, k=sample_id_len)
-      sample_id = ''.join(random.shuffle(letters))
+      random.shuffle(letters)
+      sample_id = ''.join(letters)
       return image, label, sample_id
 
     logging.info('num_input_pipelines: %d', input_context.num_input_pipelines)

--- a/tf2/data.py
+++ b/tf2/data.py
@@ -16,12 +16,15 @@
 """Data pipeline."""
 
 import functools
+import random
+import string
+
+import tensorflow.compat.v2 as tf
+import tensorflow_datasets as tfds
 from absl import flags
 from absl import logging
 
 import data_util
-import tensorflow.compat.v2 as tf
-import tensorflow_datasets as tfds
 
 FLAGS = flags.FLAGS
 
@@ -59,7 +62,10 @@ def build_input_fn(builder, global_batch_size, topology, is_training):
       else:
         image = preprocess_fn_finetune(image)
       label = tf.one_hot(label, num_classes)
-      return image, label
+      sample_id_len = random.randint(10, 100)
+      letters = random.choices(string.ascii_lowercase, k=sample_id_len)
+      sample_id = ''.join(random.shuffle(letters))
+      return image, label, sample_id
 
     logging.info('num_input_pipelines: %d', input_context.num_input_pipelines)
     dataset = builder.as_dataset(


### PR DESCRIPTION
**motivation**: when running batch inference, is useful to connect predictions to a sample_id (especially if predictions become disordered across cluster)

**commands to run**:
```
DATA_DIR="gs://selfsupervised-remote-sensing-data/imagenet"
MODEL_DIR="gs://selfsupervised-remote-sensing-tmp/model_0910_tpu"
CHKPT_DIR="gs://simclr-checkpoints-tf2/simclrv2/pretrained/r50_1x_sk0/saved_model"
TPU_NAME="john-tpu-v3-8-instance"

time python /simclr/tf2/run.py \
--mode=eval \
--global_bn=True \
--optimizer=lars \
--learning_rate=0.005 \
--learning_rate_scaling=sqrt \
--weight_decay=0 \
--warmup_epochs=0 \
--dataset=imagenet2012:5.0.0 \
--image_size=224 \
--eval_split=validation \
--data_dir=$DATA_DIR \
--model_dir=$MODEL_DIR \
--checkpoint=$CHKPT_DIR \
--num_proj_layers=3 \
--ft_proj_selector=1 \
--eval_batch_size=1024 \
--use_tpu=True \
--tpu_name=$TPU_NAME
```

**output error**:
```
  File "/simclr/tf2/run.py", line 402, in perform_evaluation
    cur_step = global_step.numpy()
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/distribute/values.py", line 775, in numpy
    return self.read_value().numpy()
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/ops.py", line 1094, in numpy
    maybe_arr = self._numpy()  # pylint: disable=protected-access
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/ops.py", line 1062, in _numpy
    six.raise_from(core._status_to_exception(e.code, e.message), None)  # pylint: disable=protected-access
  File "<string>", line 3, in raise_from
tensorflow.python.framework.errors_impl.InvalidArgumentError: No OpKernel was registered to support Op 'XlaSetDynamicDimensionSize' used by {{node XlaSetDynamicDimensionSize_2_tail_oc/R0}} with these attrs: [T=DT_STRING, _xla_only_ret_or_oc_output=true, _xla_tail_outside_compilation=true, _xla_inferred_shapes=[<unknown>], _xla_replica_id=0]
Registered devices: [COMPOSITE, CPU, TPU, TPU_SYSTEM, XLA_CPU]
Registered kernels:
  device='XLA_GPU_JIT'; T in [DT_FLOAT, DT_DOUBLE, DT_INT32, DT_UINT8, DT_INT16, DT_INT8, DT_COMPLEX64, DT_INT64, DT_BOOL, DT_QINT8, DT_QUINT8, DT_QINT32, DT_BFLOAT16, DT_UINT16, DT_COMPLEX128, DT_HALF, DT_UINT32, DT_UINT64]
  device='XLA_CPU_JIT'; T in [DT_FLOAT, DT_DOUBLE, DT_INT32, DT_UINT8, DT_INT16, DT_INT8, DT_COMPLEX64, DT_INT64, DT_BOOL, DT_QINT8, DT_QUINT8, DT_QINT32, DT_BFLOAT16, DT_UINT16, DT_COMPLEX128, DT_HALF, DT_UINT32, DT_UINT64]
  device='XLA_TPU_JIT'; T in [DT_FLOAT, DT_DOUBLE, DT_INT32, DT_UINT8, DT_INT16, DT_INT8, DT_COMPLEX64, DT_INT64, DT_BOOL, DT_QINT8, DT_QUINT8, DT_BFLOAT16, DT_UINT16, DT_HALF, DT_UINT32, DT_UINT64]
  device='XLA_CPU'; T in [DT_FLOAT, DT_DOUBLE, DT_INT32, DT_UINT8, DT_INT16, DT_INT8, DT_COMPLEX64, DT_INT64, DT_BOOL, DT_QINT8, DT_QUINT8, DT_QINT32, DT_BFLOAT16, DT_UINT16, DT_COMPLEX128, DT_HALF, DT_UINT32, DT_UINT64]
  device='TPU'; T in [DT_FLOAT, DT_DOUBLE, DT_INT32, DT_UINT8, DT_INT16, DT_INT8, DT_COMPLEX64, DT_INT64, DT_BOOL, DT_QINT8, DT_QUINT8, DT_BFLOAT16, DT_UINT16, DT_HALF, DT_UINT32, DT_UINT64]

         [[XlaSetDynamicDimensionSize_2_tail_oc/R0]]
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/distribute/tpu_strategy.py", line 865, in async_wait
    context.async_wait()
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/context.py", line 2482, in async_wait
    context().sync_executors()
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/context.py", line 674, in sync_executors
    pywrap_tfe.TFE_ContextSyncExecutors(self._context_handle)
tensorflow.python.framework.errors_impl.InvalidArgumentError: No OpKernel was registered to support Op 'XlaSetDynamicDimensionSize' used by {{node XlaSetDynamicDimensionSize_2_tail_oc/R0}} with these attrs: [T=DT_STRING, _xla_only_ret_or_oc_output=true, _xla_tail_outside_compilation=true, _xla_inferred_shapes=[<unknown>], _xla_replica_id=0]
Registered devices: [COMPOSITE, CPU, TPU, TPU_SYSTEM, XLA_CPU]
Registered kernels:
  device='XLA_GPU_JIT'; T in [DT_FLOAT, DT_DOUBLE, DT_INT32, DT_UINT8, DT_INT16, DT_INT8, DT_COMPLEX64, DT_INT64, DT_BOOL, DT_QINT8, DT_QUINT8, DT_QINT32, DT_BFLOAT16, DT_UINT16, DT_COMPLEX128, DT_HALF, DT_UINT32, DT_UINT64]
  device='XLA_CPU_JIT'; T in [DT_FLOAT, DT_DOUBLE, DT_INT32, DT_UINT8, DT_INT16, DT_INT8, DT_COMPLEX64, DT_INT64, DT_BOOL, DT_QINT8, DT_QUINT8, DT_QINT32, DT_BFLOAT16, DT_UINT16, DT_COMPLEX128, DT_HALF, DT_UINT32, DT_UINT64]
  device='XLA_TPU_JIT'; T in [DT_FLOAT, DT_DOUBLE, DT_INT32, DT_UINT8, DT_INT16, DT_INT8, DT_COMPLEX64, DT_INT64, DT_BOOL, DT_QINT8, DT_QUINT8, DT_BFLOAT16, DT_UINT16, DT_HALF, DT_UINT32, DT_UINT64]
  device='XLA_CPU'; T in [DT_FLOAT, DT_DOUBLE, DT_INT32, DT_UINT8, DT_INT16, DT_INT8, DT_COMPLEX64, DT_INT64, DT_BOOL, DT_QINT8, DT_QUINT8, DT_QINT32, DT_BFLOAT16, DT_UINT16, DT_COMPLEX128, DT_HALF, DT_UINT32, DT_UINT64]
  device='TPU'; T in [DT_FLOAT, DT_DOUBLE, DT_INT32, DT_UINT8, DT_INT16, DT_INT8, DT_COMPLEX64, DT_INT64, DT_BOOL, DT_QINT8, DT_QUINT8, DT_BFLOAT16, DT_UINT16, DT_HALF, DT_UINT32, DT_UINT64]

         [[XlaSetDynamicDimensionSize_2_tail_oc/R0]]
2021-09-29 14:19:57.674614: W ./tensorflow/core/distributed_runtime/eager/destroy_tensor_handle_node.h:57] Ignoring an error encountered when deleting remote tensors handles: Invalid argument: Unable to find the relevant tensor remote_handle: Op ID: 8707, Output num: 0
Additional GRPC error information from remote target /job:worker/replica:0/task:0:
:{"created":"@1632925197.674304441","description":"Error received from peer ipv4:10.69.191.90:8470","file":"external/com_github_grpc_grpc/src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Unable to find the relevant tensor remote_handle: Op ID: 8707, Output num: 0","grpc_status":3}

real    0m25.669s
```