### PR TITLE
binary accuracy

### DIFF
--- a/tf2/metrics.py
+++ b/tf2/metrics.py
@@ -56,10 +56,15 @@ def update_finetune_metrics_train(supervised_loss_metric, supervised_acc_metric,
 
 
 def update_finetune_metrics_eval(label_top_1_accuracy_metrics,
-                                 label_top_5_accuracy_metrics, outputs, labels):
+                                 label_top_5_accuracy_metrics,,
+                                 label_binary_accruacy, outputs, labels):
   label_top_1_accuracy_metrics.update_state(
       tf.argmax(labels, 1), tf.argmax(outputs, axis=1))
   label_top_5_accuracy_metrics.update_state(labels, outputs)
+
+  binary_accuracy = tf.keras.metrics.binary_accuracy(tf.cast(labels, tf.float32), outputs)  # threshold = 0.5
+  binary_accuracy = tf.reduce_mean(binary_accuracy)
+  label_binary_accruacy.update_state(binary_accuracy)
 
 
 def _float_metric_value(metric):

--- a/tf2/metrics.py
+++ b/tf2/metrics.py
@@ -56,7 +56,7 @@ def update_finetune_metrics_train(supervised_loss_metric, supervised_acc_metric,
 
 
 def update_finetune_metrics_eval(label_top_1_accuracy_metrics,
-                                 label_top_5_accuracy_metrics,,
+                                 label_top_5_accuracy_metrics,
                                  label_binary_accruacy, outputs, labels):
   label_top_1_accuracy_metrics.update_state(
       tf.argmax(labels, 1), tf.argmax(outputs, axis=1))

--- a/tf2/run.py
+++ b/tf2/run.py
@@ -362,8 +362,9 @@ def perform_evaluation(model, builder, eval_steps, ckpt, strategy, topology):
         'eval/label_top_1_accuracy')
     label_top_5_accuracy = tf.keras.metrics.TopKCategoricalAccuracy(
         5, 'eval/label_top_5_accuracy')
+    label_binary_accruacy = tf.keras.metrics.Mean('eval/binary_accuracy')
     all_metrics = [
-        regularization_loss, label_top_1_accuracy, label_top_5_accuracy
+        regularization_loss, label_top_1_accuracy, label_top_5_accuracy, label_binary_accruacy
     ]
 
     # Restore checkpoint.
@@ -380,7 +381,7 @@ def perform_evaluation(model, builder, eval_steps, ckpt, strategy, topology):
     outputs = supervised_head_outputs
     l = labels['labels']
     metrics.update_finetune_metrics_eval(label_top_1_accuracy,
-                                         label_top_5_accuracy, outputs, l)
+                                         label_top_5_accuracy, label_binary_accruacy, outputs, l)
     reg_loss = model_lib.add_weight_decay(model, adjust_per_optimizer=True)
     regularization_loss.update_state(reg_loss)
 


### PR DESCRIPTION
binary accuracy metric prints `nan` for TPU distributed, works for single GPU

```
I0929 14:37:51.547559 140337606711104 run.py:399] Completed eval for 48 / 49 steps
I0929 14:37:51.550273 140337606711104 run.py:399] Completed eval for 49 / 49 steps
I0929 14:37:51.550378 140337606711104 run.py:400] Finished eval for gs://selfsupervised-remote-sensing-tmp/model_0910_tpu/ckpt-2502
I0929 14:38:32.690857 140337606711104 run.py:404] Writing summaries for 2502 step
I0929 14:38:32.695981 140337606711104 metrics.py:78] Step: [2502] eval/regularization_loss = 0.000000
I0929 14:38:32.703016 140337606711104 metrics.py:78] Step: [2502] eval/label_top_1_accuracy = 0.017680
I0929 14:38:32.708694 140337606711104 metrics.py:78] Step: [2502] eval/label_top_5_accuracy = 0.063320
I0929 14:38:32.714236 140337606711104 metrics.py:78] Step: [2502] eval/binary_accuracy = nan
```